### PR TITLE
Create vim-keyboard-shortcuts.markdown

### DIFF
--- a/_drafts/vim-keyboard-shortcuts.markdown
+++ b/_drafts/vim-keyboard-shortcuts.markdown
@@ -1,0 +1,6 @@
+---
+layout: post
+title: VIM Keyboard Shortcuts
+---
+
+To resize all windows to equal dimensions based on their splits, you can use `Ctrl-w =`.


### PR DESCRIPTION
### Quickfix
```
cl - list quickfix in a split window horizontal.
cc # display on the nth quickfix item.
```

### search and replace
```
:s/foo/bar/g
```
Use `\V` to treat only `\` as special.
```
:s /\V[ChekkanBlog]//g
```
`[` and `]` are metacharacters. `\V` stops it from being a metacharacter. See `:help magic` more documentation. 

The above command removes `[ChekkanBlog]` on the current line. 